### PR TITLE
Fixed erroneous error message for missing --out

### DIFF
--- a/src/main/java/abra/ReAlignerOptions.java
+++ b/src/main/java/abra/ReAlignerOptions.java
@@ -127,12 +127,12 @@ public class ReAlignerOptions extends Options {
 		
 		if (!getOptions().hasArgument(INPUT_SAM)) {
 			isValid = false;
-			System.err.println("Missing required input SAM/BAM file");
+			System.err.println("Missing required input SAM/BAM file(s)");
 		}
 
 		if (!getOptions().hasArgument(OUTPUT_SAM)) {
 			isValid = false;
-			System.err.println("Missing required input SAM/BAM file");
+			System.err.println("Missing required output SAM/BAM filename(s)");
 		}
 		
 		if (getInputFiles().length != getOutputFiles().length) {


### PR DESCRIPTION
--out used to have the same error message as --in.